### PR TITLE
简化了MapPolygon.maskout，修改了drawing中裁剪的制作。

### DIFF
--- a/cnmaps/drawing.py
+++ b/cnmaps/drawing.py
@@ -8,41 +8,30 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath
 import cartopy.crs as ccrs
+from cartopy.mpl.patch import geos_to_path
 import shapely.geometry as sgeom
-import shapely.ops as sops
+from shapely.ops import transform
 from geopandas import GeoDataFrame
 from pyproj import Transformer
 
 from .maps import MapPolygon
 
+def _transform_polygon(map_polygon, crs_from, crs_to):
+    if crs_from == crs_to:
+        return map_polygon
+    else:
+        transformer = Transformer.from_crs(crs_from, crs_to, always_xy=True)
+        return transform(transformer.transform, map_polygon)
 
 def _make_clip_path(map_polygon):
-    vertices = []
-    codes = []
-    clips = []
-
     ax = plt.gca()
-    crs_from = ccrs.PlateCarree()
-    crs_to = ax.projection
-    if crs_from != crs_to:
-        transformer = Transformer.from_crs(crs_from, crs_to, always_xy=True)
-        map_polygon = sops.transform(transformer.transform, map_polygon)
+    map_polygon = _transform_polygon(map_polygon, ccrs.PlateCarree(), ax.projection)
 
-    for polygon in map_polygon.geoms:
-        coords = polygon.boundary.coords
-        prt = len(coords)
-        for coord in coords:
-            vertices.append(coord)
-        codes += [mpath.Path.MOVETO]
-        codes += [mpath.Path.LINETO] * (prt - 2)
-        codes += [mpath.Path.CLOSEPOLY]
-        _clip = mpath.Path(vertices, codes)
-        clip = mpatches.PathPatch(_clip, transform=ax.transData)
+    paths = geos_to_path(map_polygon)
+    path = mpath.Path.make_compound_path(*paths)
+    clip = mpatches.PathPatch(path, transform=ax.transData)
 
-        clips.append(clip)
-
-    return clips
-
+    return clip
 
 def clip_contours_by_map(contours, map_polygon: MapPolygon):
     """
@@ -75,11 +64,10 @@ def clip_contours_by_map(contours, map_polygon: MapPolygon):
         >>> clip_contours_by_map(cs, map_polygon)
         >>> draw_map(map_polygon, color='k', linewidth=1)
     """
-    clips = _make_clip_path(map_polygon)
+    clip = _make_clip_path(map_polygon)
 
-    for clip in clips:
-        for contour in contours.collections:
-            contour.set_clip_path(clip)
+    for contour in contours.collections:
+        contour.set_clip_path(clip)
 
 
 def clip_pcolormesh_by_map(mesh, map_polygon: MapPolygon):
@@ -112,10 +100,9 @@ def clip_pcolormesh_by_map(mesh, map_polygon: MapPolygon):
     >>> clip_pcolormesh_by_map(mesh, map_polygon)
     >>> draw_map(map_polygon, linewidth=1)
     """
-    clips = _make_clip_path(map_polygon)
+    clip = _make_clip_path(map_polygon)
 
-    for clip in clips:
-        mesh.set_clip_path(clip)
+    mesh.set_clip_path(clip)
 
 
 def clip_quiver_by_map(quiver, map_polygon: MapPolygon):
@@ -150,10 +137,9 @@ def clip_quiver_by_map(quiver, map_polygon: MapPolygon):
     >>> clip_quiver_by_map(quiver, map_polygon)
     >>> draw_map(map_polygon, linewidth=1)
     """
-    clips = _make_clip_path(map_polygon)
+    clip = _make_clip_path(map_polygon)
 
-    for clip in clips:
-        quiver.set_clip_path(clip)
+    quiver.set_clip_path(clip)
 
 
 def clip_scatter_by_map(scatter, map_polygon: MapPolygon):
@@ -197,10 +183,9 @@ def clip_scatter_by_map(scatter, map_polygon: MapPolygon):
     >>> clip_scatter_by_map(scatter, map_polygon)
     >>> draw_map(map_polygon, linewidth=1)
     """
-    clips = _make_clip_path(map_polygon)
+    clip = _make_clip_path(map_polygon)
 
-    for clip in clips:
-        scatter.set_clip_path(clip)
+    scatter.set_clip_path(clip)
 
 
 def clip_clabels_by_map(clabel_text: matplotlib.text.Text, map_polygon: MapPolygon):
@@ -243,27 +228,12 @@ def clip_clabels_by_map(clabel_text: matplotlib.text.Text, map_polygon: MapPolyg
     >>> draw_map(map_polygon, color='k')
     """
     ax = plt.gca()
-    crs_from = ccrs.PlateCarree()
-    crs_to = ax.projection
-    if crs_from != crs_to:
-        transformer = Transformer.from_crs(crs_from, crs_to, always_xy=True)
-        map_polygon = sops.transform(transformer.transform, map_polygon)
+    map_polygon = _transform_polygon(map_polygon, ccrs.PlateCarree(), ax.projection)
 
     for cbt in clabel_text:
-        cbt.set_visible(False)
-
-    for polygon in map_polygon.geoms:
-        vertices = []
-        coords = polygon.boundary.coords
-        for coord in coords:
-            vertices.append(coord)
-
-        _polygon = sgeom.Polygon(vertices)
-
-        for cbt in clabel_text:
-            if _polygon.contains(sgeom.Point(cbt.get_position())):
-                cbt.set_visible(True)
-
+        point = sgeom.Point(cbt.get_position())
+        if not map_polygon.contains(point):
+            cbt.set_visible(False)
 
 def draw_map(map_polygon: Union[MapPolygon, sgeom.MultiLineString], **kwargs):
     """
@@ -288,11 +258,7 @@ def draw_map(map_polygon: Union[MapPolygon, sgeom.MultiLineString], **kwargs):
         >>> draw_map(get_adm_maps(city='北京市', level='市', only_polygon=True, record='first'))
     """
     ax = plt.gca()
-    crs_from = ccrs.PlateCarree()
-    crs_to = ax.projection
-    if crs_from != crs_to:
-        transformer = Transformer.from_crs(crs_from, crs_to, always_xy=True)
-        map_polygon = sops.transform(transformer.transform, map_polygon)
+    map_polygon = _transform_polygon(map_polygon, ccrs.PlateCarree(), ax.projection)
 
     if "color" not in kwargs and "c" not in kwargs:
         kwargs["color"] = "k"

--- a/cnmaps/drawing.py
+++ b/cnmaps/drawing.py
@@ -16,12 +16,14 @@ from pyproj import Transformer
 
 from .maps import MapPolygon
 
+
 def _transform_polygon(map_polygon, crs_from, crs_to):
     if crs_from == crs_to:
         return map_polygon
     else:
         transformer = Transformer.from_crs(crs_from, crs_to, always_xy=True)
         return transform(transformer.transform, map_polygon)
+
 
 def _make_clip_path(map_polygon):
     ax = plt.gca()
@@ -32,6 +34,7 @@ def _make_clip_path(map_polygon):
     clip = mpatches.PathPatch(path, transform=ax.transData)
 
     return clip
+
 
 def clip_contours_by_map(contours, map_polygon: MapPolygon):
     """
@@ -234,6 +237,7 @@ def clip_clabels_by_map(clabel_text: matplotlib.text.Text, map_polygon: MapPolyg
         point = sgeom.Point(cbt.get_position())
         if not map_polygon.contains(point):
             cbt.set_visible(False)
+
 
 def draw_map(map_polygon: Union[MapPolygon, sgeom.MultiLineString], **kwargs):
     """

--- a/cnmaps/maps.py
+++ b/cnmaps/maps.py
@@ -182,6 +182,15 @@ class MapPolygon(sgeom.MultiPolygon):
         Returns:
             np.ndarray: 遮罩（掩膜）数组
         """
+        lons = np.atleast_1d(lons)
+        lats = np.atleast_1d(lats)
+
+        if len(lons.shape) != 2 or len(lats.shape) != 2:
+            raise ValueError("x或y不是2维数组")
+
+        if lons.shape != lats.shape:
+            raise ValueError("x和y的形状不匹配")
+
         return ~contains(self, lons, lats)
 
 

--- a/cnmaps/maps.py
+++ b/cnmaps/maps.py
@@ -169,9 +169,21 @@ class MapPolygon(sgeom.MultiPolygon):
         if not isinstance(ndata, np.ma.MaskedArray):
             ndata = np.ma.MaskedArray(ndata)
 
-        ndata.mask = ~contains(self, lons, lats)
+        ndata.mask = self.make_mask_array(lons, lats)
 
         return ndata
+
+    def make_mask_array(self, lons: np.ndarray, lats: np.ndarray):
+        """
+        生成边界以外的遮罩（掩膜）数组
+        Args:
+            lons (np.ndarray): 经度矩阵（2维）
+            lats (np.ndarray): 纬度矩阵（2维）
+        Returns:
+            np.ndarray: 遮罩（掩膜）数组
+        """
+        return ~contains(self, lons, lats)
+
 
 def read_mapjson(fp, wgs84=True):
     """


### PR DESCRIPTION
对于 [Issue#74](https://github.com/cnmetlab/cnmaps/issues/74) 的问题，用 line_profiler 查看发现大部分时间都花在了 `_make_clip_path` 中新建 `Path` 对象的语句上

```Python
_clip = mpath.Path(vertices, codes)
```

参考 [气象绘图加强版（十二）——白化杂谈](https://mp.weixin.qq.com/s/CGjvTAIArmZEp9N0B0jrew) 中对 `cartopy.mpl.patch.geos_to_path` 函数的使用，重写了 `_make_clip_path` 函数，输入一个 `map_polygon` 只会返回一个 `Path`，可以直接用来裁剪 `Collection` 对象。以 [Issue#74](https://github.com/cnmetlab/cnmaps/issues/74) 的代码为例，修改前我的本地运行时间是 33 秒，修改后变为 1.5 秒。修改后 `drawing` 中各种 `clip_` 函数的效果按文档的代码进行了测试，未发现异常。

`MapPolygon.maskout` 之前用的是递归的算法，我在看 [regionmask 的文档](https://regionmask.readthedocs.io/en/stable/notebooks/method.html) 时发现 regionmask 用了 `shapely.vectorized.contains` 函数，一行就能生成掩膜

```Python
from shapely.vectorized import contains
contains(map_polygon, lons, lats)
```

就可以把那一大段代码替换成简单的一行。测试速度如下

![timing_new](https://user-images.githubusercontent.com/54382968/185412780-4d5ab7c9-5fb8-46b8-9ff4-c0f02c87055c.png)

橙色的是 `shapely.vectorized.contains` 方法，除非点特别多，不然其速度会更快一些。